### PR TITLE
Get the Docker interface IP address properly

### DIFF
--- a/tests/forklift/test_services.py
+++ b/tests/forklift/test_services.py
@@ -21,6 +21,7 @@ import contextlib
 import tempfile
 import yaml
 
+from forklift.drivers import ip_address
 from tests.base import (
     docker,
     DOCKER_BASE_IMAGE,
@@ -229,7 +230,7 @@ class DockerEnvironmentTestCase(CaptureEnvironmentMixin, TestCase):
     @staticmethod
     def localhost_reference():
         # TODO: Can this change?
-        return '172.17.42.1'
+        return ip_address('docker0')
 
     def capture_env(self, *args, prepend_args=None):
         """


### PR DESCRIPTION
When running Docker in Docker, the IP address of docker0 interface
changes. Look it up instead of hardcoding.
