### PR TITLE
Use exec to start commands

### DIFF
--- a/forklift/drivers.py
+++ b/forklift/drivers.py
@@ -76,7 +76,8 @@ class Driver(object):
 
         A hook point for overriding in tests.
         """
-        return subprocess.call(command)
+
+        os.execvp(command[0], command)
 
     def base_environment(self):
         """


### PR DESCRIPTION
Closes #9
Because there is no child process anymore - Forklift simply exec()s what's needed.
