### PR TITLE
Fix SSH polluting known_hosts

### DIFF
--- a/forklift/drivers.py
+++ b/forklift/drivers.py
@@ -425,9 +425,12 @@ class Docker(Driver):
         for _ in range(1, 120):
             try:
                 subprocess.check_call(
-                    ssh_command + ['-o', 'StrictHostKeyChecking=no',
-                                   '-o', 'PasswordAuthentication=no',
-                                   'true'],
+                    ssh_command + [
+                        '-o', 'StrictHostKeyChecking=no',
+                        '-o', 'PasswordAuthentication=no',
+                        '-o', 'NoHostAuthenticationForLocalhost=yes',
+                        '/bin/true',
+                    ],
                     stdin=DEVNULL,
                     stdout=DEVNULL,
                     stderr=DEVNULL,

--- a/tests/forklift/test_sshd.py
+++ b/tests/forklift/test_sshd.py
@@ -96,7 +96,9 @@ class SSHTestCase(TestCase):
 
             self.assertTrue(available)
             self.assertEqual(0, subprocess.call(
-                command + ' /bin/true',
+                command +
+                ' -o NoHostAuthenticationForLocalhost=yes' +
+                ' /bin/true',
                 shell=True
             ))
         finally:


### PR DESCRIPTION
In case NoHostAuthenticationForLocalhost is not specified in user's SSH
configuration, starting the SSH daemon will write to the known_hosts
file, potentially leading to conflicts later when the same port is
reused.
Test the SSH connection with the option on, but without touching the
user's configuration.
