### PR TITLE
Partially fix passing environment through to SSH mode

### DIFF
--- a/forklift/drivers.py
+++ b/forklift/drivers.py
@@ -338,7 +338,9 @@ class Docker(Driver):
         commands = [
             'DEBIAN_FRONTEND=noninteractive apt-get -qq install dropbear sudo',
         ] + [
-            'echo \'{0}={1}\' >> /etc/profile'.format(*env)
+            # TODO: this only passes the environment to shells.
+            # Commands run directly (ssh ... command) get no environment.
+            'echo \'export {0}={1}\' >> /etc/profile'.format(*env)
             for env in self.environment().items()
         ] + [
             '(useradd -m {user} || true)',

--- a/tests/base.py
+++ b/tests/base.py
@@ -253,3 +253,17 @@ def redirect_stream(target_fd, stream=None):
 
     os.close(stream_fileno)
     os.dup2(saved_stream, stream_fileno)
+
+
+def parse_environment(env_string):
+    """
+    Parse the output of 'env -0' into a dictionary.
+    """
+
+    if type(env_string) is bytes:
+        env_string = env_string.decode()
+
+    return dict(
+        item.split('=', 1)
+        for item in env_string.rstrip('\0').split('\0')
+    )

--- a/tests/forklift/test_forklift.py
+++ b/tests/forklift/test_forklift.py
@@ -26,6 +26,7 @@ import forklift
 from forklift.drivers import ip_address
 from tests.base import (
     docker,
+    parse_environment,
     redirect_stream,
     DOCKER_BASE_IMAGE,
     SaveOutputMixin,
@@ -144,11 +145,7 @@ class CaptureEnvironmentMixin(object):
 
         self.assertEqual(0, self.run_forklift(*forklift_args))
 
-        output = SaveOutputMixin.last_output()
-        return dict(
-            item.split('=', 1)
-            for item in output.rstrip('\0').split('\0')
-        )
+        return parse_environment(SaveOutputMixin.last_output())
 
     @contextlib.contextmanager
     def configuration_file(self, configuration):


### PR DESCRIPTION
Dropbear doesn't have a facility to add arbitrary environment to client
processes; fix /etc/profile workaround to work at least for shells.
