### PR TITLE
Update for API 1.19 (Docker 1.7)

### DIFF
--- a/forklift/services/base.py
+++ b/forklift/services/base.py
@@ -717,7 +717,7 @@ def get_or_create_container(docker_client,
         docker_client.create_container(
             image,
             name=container_name,
-            ports=(port,),
+            ports={port: {}},
             **kwargs
         )
         container_status = docker_client.inspect_container(container_name)

--- a/tests/forklift/test_cleanroom.py
+++ b/tests/forklift/test_cleanroom.py
@@ -17,6 +17,8 @@
 Test the --rm and --transient flags
 """
 
+import re
+
 import docker
 import docker.errors
 
@@ -102,7 +104,7 @@ class TestRm(TestCase):
 
         ex = ex.exception
         self.assertEqual(ex.response.status_code, 404)
-        self.assertRegex(ex.explanation, b'No such container')
+        self.assertRegex(ex.explanation, re.compile(b'no such', re.IGNORECASE))
 
 
 class TestTransient(TestCase):


### PR DESCRIPTION
- Change port mapping to a map from ports to empty structures. This
  seems to be the new format even though it's not documented.
- Update test for the new error message