### PR TITLE
Fix creating containers with mounted volumes

### DIFF
--- a/forklift/services/base.py
+++ b/forklift/services/base.py
@@ -712,7 +712,7 @@ def get_or_create_container(docker_client,
 
         if data_dir is not None:
             # Ensure the data volume is mounted
-            kwargs.setdefault('volumes', {})[data_dir] = cached_dir
+            kwargs.setdefault('volumes', {})[data_dir] = {}
 
         docker_client.create_container(
             image,


### PR DESCRIPTION
Fixes a 500 error from Docker due to incorrect data posted to the API. Volumes are meant to be [a mapping of dirs to empty objects](https://docs.docker.com/reference/api/docker_remote_api_v1.19/#create-a-container).