### PR TITLE
Fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
     - "3.4"
     - "3.3"
-    - "3.2"
 install:
     - pip install -r dev_requirements.txt
     - pip install coveralls

--- a/tests/forklift/test_cleanroom.py
+++ b/tests/forklift/test_cleanroom.py
@@ -50,7 +50,7 @@ def assertion_forklift_class(func):
     return InnerClass
 
 
-@requires_docker_image('thatpanda/postgis')
+@requires_docker_image('mdillon/postgis')
 class TestRm(TestCase):
     """
     Test the --rm flag


### PR DESCRIPTION
New version of coverage.py no longer supports it.

Python 3.5 is supported by Forklift however PyLint does not currently support it