### PR TITLE
Fixed typographical error, changed arbitary to arbitrary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and/or specified in the codebase.
 
 Furthermore, it is often necessary to experiment within a running container.
 Forklift includes a special 'sshd' mode to start the SSH daemon instead of the
-original command, so that one can run arbitary commands inside.
+original command, so that one can run arbitrary commands inside.
 
 Installation
 ------------


### PR DESCRIPTION
@infoxchange, I've corrected a typographical error in the documentation of the [docker-forklift](https://github.com/infoxchange/docker-forklift) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.