### PR TITLE
Add compatibility with ElasticSearch 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+    - "3.5"
     - "3.4"
     - "3.3"
 install:

--- a/forklift/__init__.py
+++ b/forklift/__init__.py
@@ -22,7 +22,6 @@ user to log on to it.
 import argparse
 import logging
 import os
-import pkg_resources
 import pwd
 import socket
 import subprocess
@@ -35,7 +34,7 @@ from distutils.spawn import find_executable
 # pylint:enable=no-name-in-module,import-error
 
 from xdg.BaseDirectory import xdg_config_home
-
+import pkg_resources
 
 from forklift.arguments import argument_factory, convert_to_args, project_args
 from forklift.base import DEVNULL, ImproperlyConfigured

--- a/forklift/base.py
+++ b/forklift/base.py
@@ -17,6 +17,7 @@
 Common declarations.
 """
 
+from contextlib import contextmanager
 import os
 import socket
 import subprocess
@@ -24,8 +25,6 @@ import tempfile
 import time
 
 import psutil
-
-from contextlib import contextmanager
 
 
 def free_port():

--- a/forklift/services/elasticsearch.py
+++ b/forklift/services/elasticsearch.py
@@ -104,7 +104,7 @@ class Elasticsearch(URLService):
             url = replace_part(url, path='')
             es_response = urllib.request.urlopen(url.geturl())
             es_status = json.loads(es_response.read().decode())
-            if es_status['status'] != 200:
+            if es_status.get('status', es_response.status) != 200:
                 raise ProviderNotAvailable(
                     ("Provider '{}' is not yet available: HTTP response "
                      "{}\n{}").format(self.__class__.__name__,

--- a/pylintrc
+++ b/pylintrc
@@ -7,9 +7,6 @@
 # pygtk.require().
 #init-hook=
 
-# Profiled execution.
-profile=no
-
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
 ignore=
@@ -43,10 +40,6 @@ reports=yes
 # number of statements analyzed. This is used by the global evaluation report
 # (RP0004).
 evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
-
-# Add a comment according to your evaluation note. This is used by the global
-# evaluation report (RP0004).
-comment=no
 
 # Template used to display messages. This is a python new-style format string
 # used to format the message information. See doc for all details
@@ -89,9 +82,6 @@ disable=
 
 
 [BASIC]
-
-# Required attributes for module, separated by a comma
-required-attributes=
 
 # List of builtins function names that should not be used, separated by a comma
 bad-functions=map,filter,apply
@@ -152,10 +142,6 @@ ignore-mixin-members=yes
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set).
 ignored-classes=SQLObject
-
-# When zope mode is activated, add a predefined set of Zope acquired attributes
-# to generated-members.
-zope=no
 
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E0201 when accessed. Python regular
@@ -256,10 +242,6 @@ max-public-methods=20
 
 
 [CLASSES]
-
-# List of interface methods to ignore, separated by a comma. This is used for
-# instance to not check methods defines in Zope's Interface base class.
-ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
 
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,__new__,setUp

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,9 @@
 Setup script.
 """
 
-from setuptools import setup, find_packages
 from sys import version_info
+
+from setuptools import setup, find_packages
 
 assert version_info >= (3,), "Python 3 is required."
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -24,9 +24,9 @@ import sys
 import subprocess
 import tempfile
 import unittest
-
 from functools import reduce
 try:
+    # pylint:disable=ungrouped-imports
     from subprocess import DEVNULL  # pylint:disable=no-name-in-module
 except ImportError:
     DEVNULL = open(os.devnull)


### PR DESCRIPTION
ES 2.x does not have a `status` in the this API call any more. In that scenario, just fall back to the HTTP status code.
